### PR TITLE
Close #203: use spotbugs to identify possible code problems

### DIFF
--- a/.github/workflows/continous-integration.yml
+++ b/.github/workflows/continous-integration.yml
@@ -40,3 +40,33 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Build with Gradle Wrapper
         run: ./gradlew build --warning-mode=fail -Pmicronaut.runtime=${{ matrix.runtime }}
+
+  spotbugs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: Cache Dependencies #see https://github.com/actions/cache/blob/master/examples.md#java---gradle
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-spotbugs-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-spotbugs-gradle-
+      - name: Spotbugs Checks
+        id: spotbugs_checks
+        # ignoreFailures set to true so that the xmlReport can parsed and uploaded by next step otherwise this step will fail and the findings are not visible
+        # xmlReport set to true so that the next step can parse the xml and upload the findings
+        run: ./gradlew spotbugsMain -Pspotbugs.spotbugsMainEnabled=true -Pspotbugs.xmlReport=true
+      - name: Publish Spotbugs Results
+        # TODO switch to original GHA when PR jwgmeligmeyling/spotbugs-github-action#10 is integrated
+        uses: arolfes/spotbugs-github-action@master
+        with:
+          path: '**/spotbugs/main.xml'
+          name: 'Spotbugs Checks'
+          title: 'Spotbugs Check Results'
+          threshold: 0 # apply zero-warning policy

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ camundaVersion=7.14.0
 # Latest Jersey, that implements JAX-RS 2.1 API: see https://eclipse-ee4j.github.io/jersey/download.html
 jerseyVersion=2.33
 shadowJarVersion=6.1.0
+spotbugsVersion=4.6.0
 # Prevent upload of maven-metadata.xml.sha256/sha512 files to oss.sonatype.org
 # see https://issues.sonatype.org/browse/OSSRH-53695?focusedCommentId=887733&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-887733
 # see https://github.com/gradle/gradle/issues/11308#issuecomment-554317655

--- a/micronaut-camunda-bpm-feature/build.gradle
+++ b/micronaut-camunda-bpm-feature/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id("org.jetbrains.kotlin.plugin.allopen")
     id("maven-publish")
     id("signing")
+    id("com.github.spotbugs")
 }
 
 group = "info.novatec"
@@ -130,4 +131,33 @@ signing {
 
 configurations {
     testArtifacts
+}
+
+// per default spotbugs is disabled
+// in CI the property spotbugs.spotbugsMainEnabled is passed to gradle to enable spotbugs
+spotbugsMain.enabled = project.hasProperty('spotbugs.spotbugsMainEnabled') ? project.getProperty('spotbugs.spotbugsMainEnabled') == 'true' : false
+
+// disable spotbugs for Tests
+spotbugsTest.enabled = false
+
+spotbugs {
+    ignoreFailures = true
+    effort = com.github.spotbugs.snom.Effort.MAX
+    excludeFilter = file("${projectDir}/config/spotbugs/exclude.xml")
+}
+
+// When spotbugs is executed locally, it will produce a nice HTML report
+// When spotbugs is executed in "continous integration" it will generate XML that can be parsed and uploaded to PR
+boolean xmlReport = project.hasProperty('spotbugs.xmlReport') ? project.getProperty('spotbugs.xmlReport') == 'true' : false
+spotbugsMain {
+    reports {
+        xml {
+            enabled = xmlReport
+        }
+        html {
+            enabled = !xmlReport
+            destination = file("$buildDir/reports/spotbugs/main/spotbugs.html")
+            stylesheet = 'fancy-hist.xsl'
+        }
+    }
 }

--- a/micronaut-camunda-bpm-feature/config/spotbugs/exclude.xml
+++ b/micronaut-camunda-bpm-feature/config/spotbugs/exclude.xml
@@ -1,0 +1,6 @@
+<FindBugsFilter>
+  <Match>
+    <!-- Exclude all Micronaut generated Classes -->
+    <Class name="~.*\.\$.*" />
+  </Match>
+</FindBugsFilter>

--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,7 @@ pluginManagement {
         id("com.github.johnrengelman.shadow") version "$shadowJarVersion"
         id("io.micronaut.application") version "$micronautApplicationPluginVersion"
         id("io.micronaut.library") version "$micronautLibraryPluginVersion"
+        id("com.github.spotbugs") version "$spotbugsVersion"
     }
 }
 


### PR DESCRIPTION
* added spotbugs gradle plugin
* added seperate job in GHA continous-integration that spotbugs analysis is always executed when a PR is created
* defined exclude rule that all generated classes beginning with $ are ignored