### PR TITLE
Fixed micronaut launch link

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This section describes what needs to be done to use `micronaut-camunda-bpm-featu
 The Camunda integration works with both Gradle and Maven, but we recommend using Gradle because it has better Micronaut Support.
 
 You have the following options to integrate the Camunda integration:
-* Create a new Micronaut project using [Micronaut Launch](https://micronaut.io/launch?name=micronaut-camunda&features=camunda) and check that the "camunda" feature is selected. If you don't select any database then an in-memory H2 will be included by default.
+* Create a new Micronaut project using [Micronaut Launch](https://micronaut.io/launch?name=micronaut-camunda&features=camunda-platform7) and check that the "camunda-platform7" feature is selected. If you don't select any database then an in-memory H2 will be included by default.
 * Manually add the dependency to an existing Micronaut project:
   <details>
   <summary>Click to show Gradle configuration</summary>


### PR DESCRIPTION
I think the `camunda` feature of micronaut got renamed due to the other micronaut project.  
So the link hasn't work adding the `camunda-platform7`dependency.